### PR TITLE
[License-Check-Workflow] Add licensecheck workflow for dash itself

### DIFF
--- a/.github/workflows/licensecheck.yml
+++ b/.github/workflows/licensecheck.yml
@@ -1,0 +1,23 @@
+# This workflow will check for Maven projects if the licenses of all (transitive) dependencies are vetted.
+
+name: License vetting status check
+
+on:
+  push:
+    branches: 
+      - 'master'
+  pull_request:
+    branches: 
+     - 'master'
+  issue_comment:
+    types: [created]
+
+jobs:
+  call-license-check:
+    permissions:
+      pull-requests: write
+    uses: eclipse-dash/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
+    with:
+      projectId: technology.dash
+    secrets:
+      gitlabAPIToken: ${{ secrets.GITLAB_API_TOKEN }}


### PR DESCRIPTION
@waynebeaton what do you think about adding this?
To make this fully operational we would have to request an EF Gitlab API token, like in https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/1454.
