### PR TITLE
Adapt license-check workflow to move to own eclipse-dash organization

### DIFF
--- a/.github/workflows/mavenLicenseCheck.yml
+++ b/.github/workflows/mavenLicenseCheck.yml
@@ -129,7 +129,7 @@ jobs:
 
     - name: Check license vetting status (and ask for review if requested)
       id: check-license-vetting
-      uses: eclipse/dash-licenses/.github/actions/maven-license-check-action@master
+      uses: eclipse-dash/dash-licenses/.github/actions/maven-license-check-action@master
       with:
         request-review: ${{ env.request-review }}
         project-id: ${{ inputs.projectId }}


### PR DESCRIPTION
See https://github.com/eclipse-dash/dash-licenses/issues/302

This is not critical since when calling the custom actions the redirection seem to work, but still this should be updated to be clean.