### PR TITLE
Update GitHub repository links to the new URL

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,7 +1,7 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: Eclipse Dash
 Upstream-Contact: Wayne Beaton <wayne.beaton@eclipse-foundation.org>
-Source: https://github.com/eclipse/dash-licenses
+Source: https://github.com/eclipse-dash/dash-licenses
 
 Files: CODE_OF_CONDUCT.md
 Copyright: 2023 The Eclipse Foundation

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ To use this feature, you must have committer status on at least one Eclipse proj
 * Get an [authentication token](https://gitlab.eclipse.org/-/profile/personal_access_tokens) (scope: `api`) from `gitlab.eclipse.org`;
 * Include the `-review` option;
 * Pass the token via the `-token` option; 
-* Pass the Eclipse project's repository URL (e.g., `https://github.com/eclipse/dash-licenses`) via the `-repo` option; and
+* Pass the Eclipse project's repository URL (e.g., `https://github.com/eclipse-dash/dash-licenses`) via the `-repo` option; and
 * Pass the Eclipse open source project id (e.g., `technology.dash`) via the `-project` option.
 
 Note that the options are slightly different for the [Maven plugin](README.md#maven-plugin-options).
@@ -262,7 +262,7 @@ The Maven Plugin has the following properties that can passed either via the com
 - `dash.fail` - Force the build to fail when license issues are found. Default: `false`;
 - `dash.iplab.token` - The access token for automatically creating IP Team review requests **Do not share your access token.**;
 - `dash.projectId` - The Eclipse open source project id (e.g. `technology.dash`);
-- `dash.repo` - Specify the Eclipse Project repository that is the source of the request (e.g., `https://github.com/eclipse/dash-licenses`);
+- `dash.repo` - Specify the Eclipse Project repository that is the source of the request (e.g., `https://github.com/eclipse-dash/dash-licenses`);
 - `dash.summary` - The location (where) to generate the summary file; and
 - `dash.review.summary` - The location (where) to generate the review-summary file.
 
@@ -579,7 +579,7 @@ Sort out the licenses and approval of dependencies.
  -token <token>                    The GitLab authentication token
 
 <file> is the path to a file, or "-" to indicate stdin.
-For more help and examples, see https://github.com/eclipse/dash-licenses
+For more help and examples, see https://github.com/eclipse-dash/dash-licenses
 ```
 ### Errors
 
@@ -623,7 +623,7 @@ on:
     types: [created]
 jobs:
   call-license-check:
-    uses: eclipse/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
+    uses: eclipse-dash/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
     with:
       projectId: <PROJECT-ID>
     secrets:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,4 +20,4 @@ Security updates are applied to the HEAD of the master branch.
 
 ## Reporting a Vulnerability
 
-use the Eclipse Dash License Tool's [Issue Tracker](https://github.com/eclipse/dash-licenses/issues/new) to report a vulnerability.
+use the Eclipse Dash License Tool's [Issue Tracker](https://github.com/eclipse-dash/dash-licenses/issues/new) to report a vulnerability.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -46,16 +46,16 @@
 	<name>Eclipse Dash License Tool Core and CLI</name>
 	<description>The Eclipse Dash License Tool identifies the licenses of
 		content.</description>
-	<url>https://github.com/eclipse/dash-licenses</url>
+	<url>https://github.com/eclipse-dash/dash-licenses</url>
 
 	<scm>
-		<url>https://github.com/eclipse/dash-licenses</url>
+		<url>https://github.com/eclipse-dash/dash-licenses</url>
 		<tag>HEAD</tag>
 	</scm>
 
 	<issueManagement>
 		<system>GitHub</system>
-		<url>https://github.com/eclipse/dash-licenses/issues</url>
+		<url>https://github.com/eclipse-dash/dash-licenses/issues</url>
 	</issueManagement>
 
 	<dependencies>

--- a/core/src/main/java/org/eclipse/dash/licenses/cli/CommandLineSettings.java
+++ b/core/src/main/java/org/eclipse/dash/licenses/cli/CommandLineSettings.java
@@ -297,7 +297,7 @@ public class CommandLineSettings implements ISettings {
 		final String syntax = String.format("%s [options] <file> ...", Main.class.getName());
 		final String usageHeader = "Sort out the licenses and approval of dependencies.";
 		final String usageFooter = "\n<file> is the path to a file, or \"-\" to indicate stdin. "
-				+ "\nFor more help and examples, see https://github.com/eclipse/dash-licenses";
+				+ "\nFor more help and examples, see https://github.com/eclipse-dash/dash-licenses";
 
 		formatter.printHelp(syntax, usageHeader, getOptions(), usageFooter);
 	}

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -45,16 +45,16 @@
 
 	<name>Eclipse Dash License Tool Maven Plugin</name>
 	<description>The Eclipse Dash License Tool identifies the licenses of content.</description>
-	<url>https://github.com/eclipse/dash-licenses</url>
+	<url>https://github.com/eclipse-dash/dash-licenses</url>
 
 	<scm>
-		<url>https://github.com/eclipse/dash-licenses</url>
+		<url>https://github.com/eclipse-dash/dash-licenses</url>
 	  <tag>HEAD</tag>
   </scm>
 
 	<issueManagement>
 		<system>GitHub</system>
-		<url>https://github.com/eclipse/dash-licenses/issues</url>
+		<url>https://github.com/eclipse-dash/dash-licenses/issues</url>
 	</issueManagement>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -40,17 +40,17 @@
 
 	<name>Eclipse Dash License Tool Root</name>
 	<description>The Eclipse Dash License Tool identifies the licenses of content.</description>
-	<url>https://github.com/eclipse/dash-licenses</url>
+	<url>https://github.com/eclipse-dash/dash-licenses</url>
 
 	<scm>
-		<url>https://github.com/eclipse/dash-licenses</url>
-		<developerConnection>scm:git:git@github.com:eclipse/dash-licenses.git</developerConnection>
+		<url>https://github.com/eclipse-dash/dash-licenses</url>
+		<developerConnection>scm:git:git@github.com:eclipse-dash/dash-licenses.git</developerConnection>
 		<tag>HEAD</tag>
 	</scm>
 
 	<issueManagement>
 		<system>GitHub</system>
-		<url>https://github.com/eclipse/dash-licenses/issues</url>
+		<url>https://github.com/eclipse-dash/dash-licenses/issues</url>
 	</issueManagement>
 
 	<properties>

--- a/shaded/pom.xml
+++ b/shaded/pom.xml
@@ -43,16 +43,16 @@
 
 	<name>Eclipse Dash License Tool Executable JAR</name>
 	<description>The Eclipse Dash License Tool bundled as an executable JAR.</description>
-	<url>https://github.com/eclipse/dash-licenses</url>
+	<url>https://github.com/eclipse-dash/dash-licenses</url>
 
 	<scm>
-		<url>https://github.com/eclipse/dash-licenses</url>
+		<url>https://github.com/eclipse-dash/dash-licenses</url>
 	  <tag>HEAD</tag>
 	</scm>
 
 	<issueManagement>
 		<system>GitHub</system>
-		<url>https://github.com/eclipse/dash-licenses/issues</url>
+		<url>https://github.com/eclipse-dash/dash-licenses/issues</url>
 	</issueManagement>
 
 	<dependencies>


### PR DESCRIPTION
Related to #302

The repository has been moved, but there are still links to the old repository URL in various places. In most cases, this is redirected correctly either way, but the [GitHub workflow example](https://github.com/eclipse-dash/dash-licenses/blob/master/README.md#reusable-github-workflow-for-automatic-license-check-and-ip-team-review-requests) is broken because it [doesn't follow the redirect](https://github.com/eclipse-dash/dash-licenses/issues/302#issuecomment-2233513120).

There is one URL I didn't update, which is the REUSE badge in the README file. It seems like the badge itself is only registered for the old URL, so [updating it to the new URL](https://api.reuse.software/info/github.com/eclipse-dash/dash-licenses) doesn't work. This seems like something a project maintainer would need to fix externally, if it's something that should be fixed.