### PR TITLE
Clarify GitLab API token requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ Committers can later re-run this license-check workflow from the Github actions 
 #### Requirements
 - Maven based build
 - Root pom.xml must reside in the repository root
-- An [authentication token (scope: api) from gitlab.eclipse.org](README.md#automatic-ip-team-review-requests) has to be stored in the repositories secret store(Settings -> Scrects -> Actions) with name `M2E_GITLAB_API_TOKEN`.
+- An [authentication token (scope: api) from gitlab.eclipse.org](README.md#automatic-ip-team-review-requests) has to be stored in the repositories secret store (Settings -> Secrets -> Actions) with name `<PROJECT-NAME>_GITLAB_API_TOKEN`, such that it can be used by the above workflow definition.
 
 ## Advanced Scenarios
 


### PR DESCRIPTION
I was reading the documentation and this caught my eye. It seems to me like the inconsistency was introduced in 2cbf352, where the API token name was changed in the workflow definition example, but not the text underneath.