### PR TITLE
add OSGi Metadata using bnd-maven-plugin

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -167,6 +167,28 @@
 					</dependency>
 				</dependencies>
 			</plugin>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
+				<version>6.4.0</version>
+				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>jar</id>
+						<configuration>
+							<bnd><![CDATA[
+				                -noextraheaders: true
+				                -reproducible: true
+				                
+				                Export-Package: org.eclipse.dash.licenses*
+					        ]]></bnd>
+						</configuration>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 		<resources>
 			<resource>


### PR DESCRIPTION
see #280 

this is the minimal version for osgi metadata. think we should start with that.

@waynebeaton  the license year is dynamic calculated. remove for reproducible?


