### PR TITLE
Run GH action with Java 21

### DIFF
--- a/.github/workflows/mavenLicenseCheck.yml
+++ b/.github/workflows/mavenLicenseCheck.yml
@@ -43,7 +43,7 @@ on:
         description: 'The version of Java set up to run the license-check build'
         type: string
         required: false
-        default: '17'  
+        default: '21'  
     secrets:
       gitlabAPIToken:
         description: 'The authentication token (scope: api) from gitlab.eclipse.org of the calling repository. Only required if license vetting is requested'


### PR DESCRIPTION
Eclipse Platform requires Java 21 now (https://www.eclipse.org/lists/cross-project-issues-dev/msg20005.html) which will make licensecheck fail if run on projects building against latest Eclipse Platform and every project will have to learn and apply a change like https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2674 to unbreak. This PR will keep things "just working" for downstream projects.