### PR TITLE
Let Dependabot manage GitHub Actions versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+      
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
GitHub actions are versioned and can be deprecated/disabled over time. Letting dependabot manage their updates simplifies keeping things running smoothly.

This relates to (but does not fix) issue #430 