### PR TITLE
[License-Check-Workflow] Pin versions of called external actions

### DIFF
--- a/.github/workflows/mavenLicenseCheck.yml
+++ b/.github/workflows/mavenLicenseCheck.yml
@@ -72,7 +72,7 @@ jobs:
 
     - name: Process license-vetting request
       if: env.request-review && (!env.isDependabotPR)
-      uses: actions/github-script@v7
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       with:
         script: |
           const payload = await github.rest.repos.getCollaboratorPermissionLevel({
@@ -94,23 +94,23 @@ jobs:
     # and for events triggered by PR creation/updates the ref is 'refs/pull/<PR-number>/merge'.
     # So by default only the master-branch would be considered when requesting license-reviews, but we want the PR's state.
     # Unless the PR is closed, then we want the master-branch, which allows subsequent license review requests.
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       # use default ref 'refs/pull/<PR-number>/merge' for PR-events and 'refs/heads/master' for comments if the PR is closed
       if: github.event.issue.pull_request == '' || github.event.issue.state != 'open'
       with:
         submodules: ${{ inputs.submodules }}
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         ref: 'refs/pull/${{ github.event.issue.number }}/merge'
         submodules: ${{ inputs.submodules }}
       if: github.event.issue.pull_request != '' && github.event.issue.state == 'open'
 
-    - uses: actions/setup-java@v4
+    - uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
       with:
         java-version: ${{ inputs.javaVersion }}
         distribution: 'temurin'
     - name: Cache local Maven repository
-      uses: actions/cache@v4
+      uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
       with:
         path: ~/.m2/repository
         # re-cache on changes in the pom and target files
@@ -119,7 +119,7 @@ jobs:
           ${{ runner.os }}-maven-
 
     - name: Set up Maven
-      uses: stCarolas/setup-maven@v5
+      uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
       with:
         maven-version: ${{ inputs.mavenVersion }}
 
@@ -138,7 +138,7 @@ jobs:
 
     - name: Process license check results
       if: env.request-review
-      uses: actions/github-script@v7
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       with:
         script: |
           const fs = require('fs')
@@ -189,7 +189,7 @@ jobs:
             issue_number: context.issue.number, ...context.repo, body: commentBody
           })
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
       if: always() && env.request-review
       with:
         name: '${{ inputs.projectId }}-license-vetting-summary'


### PR DESCRIPTION
Based on the discussion in https://github.com/eclipse-dash/dash-licenses/pull/431, it was discovered that the versions of called external actions are not pinned.