### PR TITLE
Add support for file-based dependency readers in LicenseCheckMojo

### DIFF
--- a/core/src/main/java/org/eclipse/dash/licenses/cli/Main.java
+++ b/core/src/main/java/org/eclipse/dash/licenses/cli/Main.java
@@ -10,7 +10,6 @@
 package org.eclipse.dash.licenses.cli;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.FileReader;

--- a/core/src/main/java/org/eclipse/dash/licenses/cli/ReaderType.java
+++ b/core/src/main/java/org/eclipse/dash/licenses/cli/ReaderType.java
@@ -1,0 +1,30 @@
+/*************************************************************************
+ * Copyright (c) 2025 Red Hat Inc. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution, and is available at https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *************************************************************************/
+package org.eclipse.dash.licenses.cli;
+
+import java.util.Locale;
+
+/**
+ * Enum for distinguishing the supported reader types.
+ */
+public enum ReaderType {
+	PNPM, NPM, YARN, FLAT;
+
+	/**
+	 * Converts an arbitrary string to the matching ReaderType. For instance:
+	 * "pnpm", "PnPm", or "PNPM" -> PNPM.
+	 *
+	 * @param value The string to be converted
+	 * @return The corresponding enum value
+	 */
+	public static ReaderType fromString(String value) {
+		return ReaderType.valueOf(value.trim().toUpperCase(Locale.ROOT));
+	}
+}

--- a/maven-plugin/src/main/java/org/eclipse/dash/licenses/maven/LicenseCheckMojo.java
+++ b/maven-plugin/src/main/java/org/eclipse/dash/licenses/maven/LicenseCheckMojo.java
@@ -11,14 +11,18 @@ package org.eclipse.dash.licenses.maven;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -34,6 +38,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.settings.Proxy;
+import org.codehaus.plexus.util.DirectoryScanner;
 import org.eclipse.dash.licenses.ContentId;
 import org.eclipse.dash.licenses.IContentId;
 import org.eclipse.dash.licenses.IProxySettings;
@@ -41,8 +46,13 @@ import org.eclipse.dash.licenses.ISettings;
 import org.eclipse.dash.licenses.LicenseChecker;
 import org.eclipse.dash.licenses.LicenseData;
 import org.eclipse.dash.licenses.cli.CSVCollector;
+import org.eclipse.dash.licenses.cli.FlatFileReader;
 import org.eclipse.dash.licenses.cli.IResultsCollector;
 import org.eclipse.dash.licenses.cli.NeedsReviewCollector;
+import org.eclipse.dash.licenses.cli.PackageLockFileReader;
+import org.eclipse.dash.licenses.cli.PnpmPackageLockFileReader;
+import org.eclipse.dash.licenses.cli.ReaderType;
+import org.eclipse.dash.licenses.cli.YarnLockFileReader;
 import org.eclipse.dash.licenses.context.LicenseToolModule;
 import org.eclipse.dash.licenses.review.CreateReviewRequestCollector;
 import org.eclipse.dash.licenses.review.GitLabSupport;
@@ -161,10 +171,46 @@ public class LicenseCheckMojo extends AbstractArtifactFilteringMojo {
 	private MavenSession mavenSession;
 
 	/**
+	 * Maven's representation of the project in the current build.
+	 */
+	@Parameter(defaultValue = "${project}", readonly = true, required = true)
+	private MavenProject project;
+
+	/**
 	 * The Maven reactor.
 	 */
 	@Parameter(defaultValue = "${reactorProjects}", readonly = true, required = true)
 	private List<MavenProject> reactorProjects;
+
+	/**
+	 * The list of configured readers, each with a reader type and a list of file
+	 * patterns.
+	 * 
+	 * Example in pom.xml:
+	 * 
+	 * <pre>
+	 * {@code
+	 * <configuration>
+	 *   <readers>
+	 *     <reader>
+	 *       <type>pnpm</type>
+	 *       <files>
+	 *         <file>frontend/pnpm-lock.yaml</file>
+	 *       </files>
+	 *     </reader>
+	 *     <reader>
+	 *       <type>npm</type>
+	 *       <files>
+	 *         <file>frontend/package-lock.json</file>
+	 *       </files>
+	 *     </reader>
+	 *   </readers>
+	 * </configuration>
+	 * }
+	 * </pre>
+	 */
+	@Parameter
+	private List<ReaderConfig> readers;
 
 	/**
 	 * Maven Security Dispatcher
@@ -216,6 +262,10 @@ public class LicenseCheckMojo extends AbstractArtifactFilteringMojo {
 			// classifier
 			deps.add(ContentId.getContentId(type, source, a.getGroupId(), a.getArtifactId(), a.getVersion()));
 		});
+
+		// read and merge the file-based dependencies
+		Collection<IContentId> fileDeps= readFileDependencyContent();
+		deps.addAll(fileDeps); 
 
 		List<IResultsCollector> collectors = new ArrayList<>();
 
@@ -294,4 +344,73 @@ public class LicenseCheckMojo extends AbstractArtifactFilteringMojo {
 				proxyServer.getPassword(), securityDispatcher, getLog());
 	}
 
+	
+	public Collection<IContentId> readFileDependencyContent() throws MojoExecutionException {
+		if (readers == null || readers.isEmpty()) {
+			getLog().warn("No readers configured. Nothing to do.");
+			return List.of();
+		}
+
+		List<IContentId> contentIds=new ArrayList<>();
+		// Iterate over all configured readers
+		for (ReaderConfig readerConfig : readers) {
+			ReaderType type = readerConfig.getReaderType();
+			List<String> filePatterns = readerConfig.getFiles();
+
+			// For each file pattern, resolve the actual files on disk
+			for (String pattern : filePatterns) {
+				List<File> matchedFiles = resolveGlobFiles(pattern);
+				for (File file : matchedFiles) {
+					getLog().info("Processing file: " + file.getAbsolutePath() + " with reader type: " + type);
+					try {
+						InputStreamReader input = new FileReader(file);
+
+						// Choose the appropriate reader for the file
+						switch (type) {
+						case PNPM:
+							contentIds.addAll( new PnpmPackageLockFileReader(input).getContentIds());
+							break;
+						case NPM:
+							contentIds.addAll(new PackageLockFileReader(input).getContentIds());
+							break;
+						case YARN:
+							contentIds.addAll(new YarnLockFileReader(input).getContentIds());
+							break;
+						case FLAT:
+							contentIds.addAll(new FlatFileReader(input).getContentIds());
+							break;
+						default:
+							throw new MojoExecutionException("Unsupported reader type: " + type);
+						}
+					} catch (FileNotFoundException e) {
+						throw new MojoExecutionException("Could nor read file: " + file.getName(), e);
+					}
+				}
+			}
+		}
+		return contentIds;
+	}
+
+	/**
+	 * Resolves a single glob pattern into a list of matching files.
+	 *
+	 * @param pattern The file pattern (glob) to scan for.
+	 * @return A list of matching File objects.
+	 */
+	private List<File> resolveGlobFiles(String pattern) {
+		File baseDir = project.getBasedir();
+
+		DirectoryScanner scanner = new DirectoryScanner();
+		scanner.setBasedir(baseDir);
+		scanner.setIncludes(new String[] { pattern });
+		scanner.scan();
+
+		String[] includedFiles = scanner.getIncludedFiles();
+		List<File> result = new ArrayList<>();
+		for (String relativePath : includedFiles) {
+			File found = new File(baseDir, relativePath);
+			result.add(found);
+		}
+		return result;
+	}
 }

--- a/maven-plugin/src/main/java/org/eclipse/dash/licenses/maven/ReaderConfig.java
+++ b/maven-plugin/src/main/java/org/eclipse/dash/licenses/maven/ReaderConfig.java
@@ -1,0 +1,53 @@
+/*************************************************************************
+ * Copyright (c) 2025 Red Hat Inc. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution, and is available at https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *************************************************************************/
+package org.eclipse.dash.licenses.maven;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.maven.plugins.annotations.Parameter;
+import org.eclipse.dash.licenses.cli.ReaderType;
+
+/**
+ * Represents the configuration for a single reader, which reader type (e.g.
+ * pnpm, npm, yarn, flat) and the file patterns to scan (list of glob patterns)
+ */
+public class ReaderConfig {
+
+	/**
+	 * The reader type string as entered in the pom.xml..
+	 */
+	@Parameter(required = true)
+	private String type;
+
+	/**
+	 * A list of file/glob patterns, e.g. "frontend/ or pnpm-lock.yaml".
+	 **/
+	@Parameter
+	private List<String> files;
+
+	/**
+	 * Convert the raw type string to our enum.
+	 * 
+	 * @return The ReaderType enum value.
+	 */
+	public ReaderType getReaderType() {
+		return ReaderType.fromString(type);
+	}
+
+	/**
+	 * Returns the file patterns or an empty list if none configured.
+	 * 
+	 * @return A non-null list of file patterns.
+	 */
+	public List<String> getFiles() {
+		return files != null ? files : Collections.emptyList();
+	}
+}


### PR DESCRIPTION
- Add `ReaderType` enum for supported reader types
- Introduce `ReaderConfig` for reader type and file patterns
- Update `LicenseCheckMojo` to handle file-based dependencies