### PR TITLE
Update README to include support for pnpm-lock.yaml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ Each individual bit of content is identified by its ClearlyDefined id. This id u
 
 The Eclipse Dash License Tool does not identify dependencies (at least not in general). Rather, the value it provides starts after the list of dependencies are identified by build tools. That is, the tool works on the list of dependencies with which is it provided (the Maven plugin is an exception to this; it does discover dependencies). Ultimately, the tool is only as good as the input with which it is provided and it is up to the committer to ensure that the input provided is correct (that is, dependencies that are not automatically discovered by build tools must also be vetted per the Eclipse IP Policy). 
 
-The CLI accepts a flat file with each line containing a content identifier (ClearlyDefined id, Maven coordinates, or NPM identifier); it also supports a small number of file formats including `package-lock.json` or `yarn.lock` files. A Maven plugin that is capable of processing a dependency list extracted from a `pom.xml` file is also provided. 
+The CLI accepts a flat file with each line containing a content identifier (ClearlyDefined id, Maven coordinates, or NPM identifier); it also supports a small number of file formats including `package-lock.json`, `pnpm-lock.yaml` or `yarn.lock` files. A Maven plugin that is capable of processing a dependency list extracted from a `pom.xml` file is also provided. 
 
 Use the `-summary <file>` option to  generate a file that contains CSV content with one line for each line of input, mapping a package to a license along with whether that content is `approved` for use by an Eclipse project or `restricted`, meaning that the Eclipse IP Team needs to have a look at the Eclipse project's use of that content. This file is suitable for augmenting the IP Log of an Eclipse open source project.
 
 The current implementation uses two sources for license information. The first source is an Eclipse Foundation service that leverages data that the Eclipse Foundation's IP Team has collected over the years (and continues to collect). When that source does not have information for a piece of content, [ClearlyDefined](https://clearlydefined.io/)'s service is used. 
 
-The idea was to have some code that can be used to check the licenses of content, but write it in a manner that would make it easy to generate, for example, a Maven plug-in. The main focus, however, has been making this work as a CLI so that it can be used to sort out licenses for Maven, `package-lock.json`, `yarn.lock`, etc.
+The idea was to have some code that can be used to check the licenses of content, but write it in a manner that would make it easy to generate, for example, a Maven plug-in. The main focus, however, has been making this work as a CLI so that it can be used to sort out licenses for Maven, `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, etc.
 
 More information about the Eclipse Dash License Tool:
 
@@ -70,7 +70,7 @@ If you're going to use the Dash License Tool's Maven plugin locally, then you'll
 
 The project uses Java 11 language features. **Java 11 or greater is required.**
 
-The Dash License Tool can read a flat file, a `package-lock.json` file, or a `yarn.lock` file. A [Maven plugin](README.md#example-maven-plugin) that works directly from the Maven Reactor is also provided.
+The Dash License Tool can read a flat file, a `package-lock.json` file, a `pnpm-lock.yaml` file or a `yarn.lock` file. A [Maven plugin](README.md#example-maven-plugin) that works directly from the Maven Reactor is also provided.
 
 In a flat file, dependencies can be expressed one-on-a-line using ClearlyDefined ids (e.g., `maven/mavencentral/org.apache.commons/commons-csv/1.8`, Maven GAVs (e.g., `org.apache.commons:commons-csv:1.8`, or and NPM Id (e.g., `npm/npmjs/-/babel-polyfill/6.26.0`).
 
@@ -419,6 +419,14 @@ The Eclipse Dash License Tool can parse a `package-lock.json` file.
 
 ```
 $ java -jar /dash-licenses/org.eclipse.dash.licenses-<version>.jar package-lock.json
+```
+
+### Example: PNPM Lock
+
+The Eclipse Dash License Tool can parse a `pnpm-lock.yaml` file. 
+
+```
+$ java -jar /dash-licenses/org.eclipse.dash.licenses-<version>.jar pnpm-lock.yaml
 ```
 
 ### Example: Yarn


### PR DESCRIPTION
Hi Wayne, @waynebeaton,

just updated the README to include the pnpm-lock.yaml file. 

Related to the my PR some time ago: https://github.com/eclipse-dash/dash-licenses/pull/339

Checked real quick if they changed anything in their latest pnpm version, but the structure of the pnpm-lock.yaml remains the same so we're good.

https://github.com/pnpm/pnpm/blob/v10.7.1/__fixtures__/fixture/pnpm-lock.yaml

