### PR TITLE
Update version

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Configure the license check plugin to be auto executed (e.g. in the `verify` pha
 		<plugin>
 			<groupId>org.eclipse.dash</groupId>
 			<artifactId>license-tool-plugin</artifactId>
-			<version>1.0.2</version>
+			<version>1.1.0</version>
 			<executions>
 				<execution>
 					<id>license-check</id>


### PR DESCRIPTION
According to https://github.com/eclipse-dash/dash-licenses/tags, `1.1.0` is the latest version. This updates the `README` accordingly to ensure smooth copy and paste of a configuraiton.