### PR TITLE
[Build] Unify com.fasterxml.jackson versions and update to 2.22.1

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -120,26 +120,11 @@
 		</dependency>
 		
 		<!-- org.gitlab4j:gilab4j-api:6.2.0 uses versions of FasterXML that have vulnerabilities. Override the version. -->
-		
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-core</artifactId>
-			<version>2.22.0</version>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-annotations</artifactId>
-			<version>2.21</version>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-			<version>2.21.3</version>
-		</dependency>
+		<!-- The following modules has direct dependencies to and thus defines the versions of jackson-core, jackson-databind and jackson-annotations too.-->
 		<dependency>
 			<groupId>com.fasterxml.jackson.module</groupId>
 			<artifactId>jackson-module-jakarta-xmlbind-annotations</artifactId>
-			<version>2.22.0</version>
+			<version>2.22.1</version>
 		</dependency>
 		
 		<!-- end -->


### PR DESCRIPTION
Unify definition of jackson versions by just declaring `jackson-module-jakarta-xmlbind-annotations` directly.
Since it requires all other relevant jackson dependencies directly, it's version wins since 'Maven picks the “nearest definition”'.